### PR TITLE
add validation step for static UIDs

### DIFF
--- a/vspec/vssexporters/vssidgen.py
+++ b/vspec/vssexporters/vssidgen.py
@@ -10,12 +10,12 @@
 #
 # Generate IDs of 4bytes size, 3 bytes incremental value + 1 byte for layer id.
 
-from anytree import PreOrderIter
+from anytree import PreOrderIter  # type: ignore
 import argparse
 from enum import Enum
 import logging
 import os
-from typing import Dict, Optional
+from typing import Dict
 from vspec import load_tree
 from vspec.model.constants import VSSTreeType
 from vspec.loggingconfig import initLogging
@@ -145,9 +145,7 @@ def export(config: argparse.Namespace, signal_root: VSSNode, print_uuid):
         yaml.dump(signals_yaml_dict, f)
 
 
-def validate_staticUIDs(
-    signals_dict: dict, validation_tree: VSSNode, config: argparse.Namespace
-) -> Optional[dict]:
+def validate_staticUIDs(signals_dict: dict, validation_tree: VSSNode, config: argparse.Namespace):
     """Check if static UIDs have changed or if new ones need to be added
     ToDos:
         - instances
@@ -159,7 +157,7 @@ def validate_staticUIDs(
         Optional[dict]: _description_
     """
 
-    def check_length(key, value, decimal_output) -> bool:
+    def check_length(key, value, decimal_output):
         """Check if static UID exists and if it's of correct length
 
         Args:

--- a/vspec/vssexporters/vssidgen.py
+++ b/vspec/vssexporters/vssidgen.py
@@ -10,25 +10,55 @@
 #
 # Generate IDs of 4bytes size, 3 bytes incremental value + 1 byte for layer id.
 
-from vspec.model.vsstree import VSSNode
+from anytree import PreOrderIter
 import argparse
+from enum import Enum
 import logging
-from typing import Dict
-import yaml
+import os
+from typing import Dict, Optional
+from vspec import load_tree
+from vspec.model.constants import VSSTreeType
 from vspec.loggingconfig import initLogging
+from vspec.model.vsstree import VSSNode
+import yaml
+
+
+class OverwriteMethod(Enum):
+    ASSIGN_NEW_ID = 1
+    OVERWRITE_ID_WITH_NEW_ID = 2
 
 
 def add_arguments(parser: argparse.ArgumentParser):
-    parser.add_argument('--gen-ID-offset', type=int, default=1,
-                        help="Offset for static ID values in YAML output (default is 1).")
-    parser.add_argument('--gen-layer-ID-offset', type=int, default=0,
-                        help="Define layer ID.")
-    parser.add_argument('--gen-no-layer', action='store_true',
-                    help="Generate static node ID without layer ID.")
-    parser.add_argument('--gen-decimal-ID', action='store_true',
-                    help="Generate static decimal ID of 3 bytes .")
+    parser.add_argument(
+        "--gen-ID-offset",
+        type=int,
+        default=1,
+        help="Offset for static ID values in YAML output (default is 1).",
+    )
+    parser.add_argument(
+        "--gen-layer-ID-offset", type=int, default=0, help="Define layer ID."
+    )
+    parser.add_argument(
+        "--gen-no-layer",
+        action="store_true",
+        help="Generate static node ID without layer ID.",
+    )
+    parser.add_argument(
+        "--gen-decimal-ID",
+        action="store_true",
+        help="Generate static decimal ID of 3 bytes .",
+    )
+    parser.add_argument(
+        "--validate-static-uid", type=str, default="", help="Path to validation file."
+    )
+    parser.add_argument(
+        "--validate-automatic-mode",
+        action="store_true",
+        help="Automatic mode for validation in case you don't want to manually "
+        "choose a method for writing new static UIDs.",
+    )
 
-    
+
 # Function to generate a split ID (3 bytes for incremental number, 1 byte for layer)
 def generate_split_id(node, id_counter, offset, layer, no_layer, decimal_output):
     node_id = (id_counter + offset) % 1000000  # Use 6 digits for the incremental number
@@ -37,32 +67,35 @@ def generate_split_id(node, id_counter, offset, layer, no_layer, decimal_output)
         return str(node_id).zfill(6), id_counter + 1  # Decimal output without layer
     else:
         if no_layer:
-            return format((node_id), '06X'), id_counter + 1  # Hexadecimal output without layer
+            return (
+                format((node_id), "06X"),
+                id_counter + 1,
+            )  # Hexadecimal output without layer
         else:
             if 0 <= layer <= 63:
                 logging.warning("Layer value from 0 to 63 is reserved for COVESA.")
             layer = min(layer, 255)  # Use 1 byte for the layer (max_layer is 0-255)
-            return format(((node_id << 8) | layer), '08X'), id_counter + 1  # Hexadecimal output with layer
-
-
-def get_node_path(node):
-    path = [node.name]
-    while node.parent:
-        node = node.parent
-        path.insert(0, node.name)
-    return ".".join(path)
+            return (
+                format(((node_id << 8) | layer), "08X"),
+                id_counter + 1,
+            )  # Hexadecimal output with layer
 
 
 def export_node(yaml_dict, node, id_counter, offset, layer, no_layer, decimal_output):
+    node_id, id_counter = generate_split_id(
+        node, id_counter, offset, layer, no_layer, decimal_output
+    )
 
-    node_id, id_counter = generate_split_id(node, id_counter, offset, layer, no_layer, decimal_output)
+    node_path = node.qualified_name()
 
-    node_path = get_node_path(node)
-    
     if decimal_output:
-        yaml_dict[node_path] = {"staticUID": node_id}  # Convert ID to a 3-digit decimal string
-    else: 
-        yaml_dict[node_path] = {"staticUID": f'0x{node_id}'}  # Convert ID to a 3-digit decimal string
+        yaml_dict[node_path] = {
+            "staticUID": node_id
+        }  # Convert ID to a 3-digit decimal string
+    else:
+        yaml_dict[node_path] = {
+            "staticUID": f"0x{node_id}"
+        }  # Convert ID to a 3-digit decimal string
 
     yaml_dict[node_path]["type"] = str(node.type.value)
     if node.unit:
@@ -70,25 +103,199 @@ def export_node(yaml_dict, node, id_counter, offset, layer, no_layer, decimal_ou
     if node.is_signal() or node.is_property():
         yaml_dict[node_path]["datatype"] = node.data_type_str
 
-
-
     for child in node.children:
-        id_counter, id_counter = export_node(yaml_dict, child, id_counter, offset, layer, no_layer, decimal_output)
+        id_counter, id_counter = export_node(
+            yaml_dict, child, id_counter, offset, layer, no_layer, decimal_output
+        )
 
     return id_counter, id_counter
 
 
 def export(config: argparse.Namespace, signal_root: VSSNode, print_uuid):
-
     logging.info("Generating YAML output...")
 
     id_counter = 0  # Initialize the ID counter
 
     signals_yaml_dict: Dict[str, str] = {}  # Use str for ID values
-    id_counter, _ = export_node(signals_yaml_dict, signal_root, id_counter, config.gen_ID_offset, config.gen_layer_ID_offset, config.gen_no_layer, config.gen_decimal_ID)
+    id_counter, _ = export_node(
+        signals_yaml_dict,
+        signal_root,
+        id_counter,
+        config.gen_ID_offset,
+        config.gen_layer_ID_offset,
+        config.gen_no_layer,
+        config.gen_decimal_ID,
+    )
 
-    with open(config.output_file, 'w') as f:
+    if config.validate_static_uid:
+        logging.info(
+            f"Now validating nodes, static UIDs, types, units and description with file '{config.validate_static_uid}'"
+        )
+        if os.path.isabs(config.validate_static_uid):
+            other_path = config.validate_static_uid
+        else:
+            other_path = os.path.join(os.getcwd(), config.validate_static_uid)
+        # ToDo: how do we know here if SIGNAL or DATA_TYPE tree
+        validation_tree = load_tree(
+            other_path, ["."], tree_type=VSSTreeType.SIGNAL_TREE
+        )
+        result_dict = validate_staticUIDs(signals_yaml_dict, validation_tree, config)
+
+    with open(config.output_file, "w") as f:
         yaml.dump(signals_yaml_dict, f)
+
+
+def validate_staticUIDs(
+    signals_dict: dict, validation_tree: VSSNode, config: argparse.Namespace
+) -> Optional[dict]:
+    """Check if static UIDs have changed or if new ones need to be added
+    ToDos:
+        - instances
+        - automatic mode --> do we overwrite with a next higher ID because data in node has changed?
+
+    Args:
+        validation_tree (VSSNode): _description_
+    Returns:
+        Optional[dict]: _description_
+    """
+
+    def check_length(key, value, decimal_output) -> bool:
+        """Check if static UID exists and if it's of correct length
+
+        Args:
+            key (str): Current key of the dict, evaluates to the qualified name of the node
+            value (dict): dict of attributes e.g. static UID
+        """
+        if not value["staticUID"]:
+            logging.error(f"Static UID for node '{key}' has not been assigned!")
+        else:
+            if decimal_output:
+                try:
+                    assert len(value["staticUID"]) == 8
+                except AssertionError:
+                    logging.error(
+                        f"AssertionError: Length of decimal static UID of {key} is incorrect, check vssidgen.py"
+                    )
+            else:
+                try:
+                    assert len(value["staticUID"]) == 10 or len(value["staticUID"]) == 8
+                except AssertionError:
+                    logging.error(
+                        f"AssertionError: Length of hex static UID of {key} is incorrect, check vssidgen.py"
+                    )
+
+    def check_type(k, v):
+        pass
+
+    def assign_new_id(
+        k: str, v: dict, assign_id: int, config: argparse.Namespace
+    ) -> None:
+        """Assignment of next higher static UID if there is a mismatch of the current 
+        file and the validation file
+
+        Args:
+            k (str): current key of dict
+            v (dict): current value of dict (also a dict)
+            assign_id (int): the highest ID found in the original file
+            config (argparse.Namespace): command line configuration from argparser
+        """
+        assign_static_uid: int = 0
+        if config.gen_decimal_ID:
+            assign_static_uid = str(assign_id).zfill(6)
+        else:
+            if config.gen_no_layer:
+                assign_static_uid = "0x" + format(assign_id, "06X")
+            else:
+                assign_static_uid = "0x" + format(
+                    assign_id << 8 | config.gen_layer_ID_offset, "08X"
+                )
+
+        v["staticUID"] = assign_static_uid
+        logging.info(f"Assigned new ID '{assign_static_uid}' for {k}")
+
+    def overwrite_current_id(k: str, v: dict, current_id) -> None:
+        """Overwrite method for the validation step of static UID assignment
+
+        Args:
+            k (str): current key of dict
+            v (dict): current value of dict (also a dict)
+            current_id (_type_): the id that you want to overwrite the old ID with
+        """
+        v["staticUID"] = current_id
+        logging.info(f"Assigned new ID '{current_id}' for {k}")
+        
+    # go to top in case we are not
+    if validation_tree.parent:
+        while validation_tree.parent:
+            validation_tree = validation_tree.parent
+
+    # need current highest id new assignments during validation
+    highest_id = 0
+    for key, value in signals_dict.items():
+        current_value: int
+        if not config.gen_no_layer and not config.gen_decimal_ID:
+            current_value = int(value["staticUID"], 16) - config.gen_ID_offset
+            current_value = (current_value ^ config.gen_layer_ID_offset) >> 8
+        else:
+            current_value = int(value["staticUID"], 16)
+        if current_value > highest_id:
+            highest_id = current_value
+
+    # tree_nodes = [node for node in PreOrderIter(tree)]
+    validation_tree_nodes = [node for node in PreOrderIter(validation_tree)]
+
+    # 1. check if all nodes have staticUID of correct length
+    for key, value in signals_dict.items():
+        check_length(key, value, decimal_output=config.gen_decimal_ID)
+
+        ## WIP: what if there was no match? we need optional method?
+
+        match_tuple = [
+            (key, id_validation_tree)
+            for id_validation_tree, other_node in enumerate(validation_tree_nodes)
+            if key == other_node.qualified_name()
+        ][0]
+
+        try:
+            assert (
+                value["staticUID"]
+                == validation_tree_nodes[match_tuple[1]].extended_attributes[
+                    "staticUID"
+                ]
+            )
+        except AssertionError:
+            logging.info(
+                f"IDs don't match what would you like to do? Current tree's node '{key}' "
+                f"has static UID '{value['staticUID']} and other "
+                f"tree's node '{validation_tree_nodes[match_tuple[1]].qualified_name()}' "
+                f"has static UID "
+                f"'{validation_tree_nodes[match_tuple[1]].extended_attributes['staticUID']}'\n1) Assign new ID\n2) Overwrite ID with new ID"
+            )
+            if config.validate_automatic_mode:
+                raise NotImplementedError(
+                    "Automatic mode has not been implemented yet!"
+                )
+            else:
+                while True:
+                    try:
+                        overwrite_method = OverwriteMethod(int(input()))
+                        if overwrite_method == OverwriteMethod.ASSIGN_NEW_ID:
+                            highest_id += 1
+                            assign_new_id(key, value, highest_id, config)
+                        elif (
+                            overwrite_method == OverwriteMethod.OVERWRITE_ID_WITH_NEW_ID
+                        ):
+                            overwrite_current_id(
+                                key, value, validation_tree_nodes[match_tuple[1]].extended_attributes['staticUID']
+                            )
+                    except ValueError:
+                        logging.info(
+                            "Wrong input please choose again\n1) Assign new ID\n2) Overwrite ID with new ID"
+                        )
+                        continue
+                    else:
+                        break
+
 
 if __name__ == "__main__":
     initLogging()


### PR DESCRIPTION
in case you want to test this please generate two vspec files without the `--validate-static-uid` argument and then manually modify the static UIDs in one of those and use the modified file as the validation file (below i manually modified `out_id_v2.vspec` and then used it for validating if the static UIDs have changed)

```bash
./vspecID.py ../vehicle_signal_specification/spec/VehicleSignalSpecification.vspec ../output_id.vspec --gen-layer-ID-offset 99 --validate-static-uid ../output_id_v2.vspec
```