### PR TITLE
add strict mode for case sensitivity

### DIFF
--- a/docs/vspec2id.md
+++ b/docs/vspec2id.md
@@ -11,7 +11,7 @@ with a 4-byte identifier.
 usage: vspec2id.py [-h] [-I dir] [-e EXTENDED_ATTRIBUTES] [-s] [--abort-on-unknown-attribute] [--abort-on-name-style] [--format format] [--uuid] [--no-expand] [-o overlays] [-u unit_file]
                    [-q quantity_file] [-vt vspec_types_file] [-ot <types_output_file>] [--json-all-extended-attributes] [--json-pretty] [--yaml-all-extended-attributes] [-v version] [--all-idl-features]
                    [--gqlfield GQLFIELD GQLFIELD] [--jsonschema-all-extended-attributes] [--jsonschema-disallow-additional-properties] [--jsonschema-require-all-properties] [--jsonschema-pretty]
-                   [--validate-static-uid VALIDATE_STATIC_UID] [--only-validate-no-export] [--strict-mode]   
+                   [--validate-static-uid VALIDATE_STATIC_UID] [--only-validate-no-export] [--strict-mode]
                    <vspec_file> <output_file>
 
 Convert vspec to other formats.

--- a/docs/vspec2id.md
+++ b/docs/vspec2id.md
@@ -1,6 +1,6 @@
 # vspec2id - vspec static UID generator and validator
 
-The vspecID.py script is used to generate and validate static UIDs for all nodes in the tree.
+The vspec2id.py script is used to generate and validate static UIDs for all nodes in the tree.
 They will be used as unique identifiers to transmit data between nodes. The static UIDs are
 implemented to replace long strings like `Vehicle.Body.Lights.DirectionIndicator.Right.IsSignaling`
 with a 4-byte identifier.
@@ -9,8 +9,9 @@ with a 4-byte identifier.
 
 ```bash
 usage: vspec2id.py [-h] [-I dir] [-e EXTENDED_ATTRIBUTES] [-s] [--abort-on-unknown-attribute] [--abort-on-name-style] [--format format] [--uuid] [--no-expand] [-o overlays] [-u unit_file]
-                   [-vt vspec_types_file] [-ot <types_output_file>] [--json-all-extended-attributes] [--json-pretty] [--yaml-all-extended-attributes] [-v version] [--all-idl-features]
-                   [--gqlfield GQLFIELD GQLFIELD] [--validate-static-uid VALIDATE_STATIC_UID] [--only-validate-no-export]
+                   [-q quantity_file] [-vt vspec_types_file] [-ot <types_output_file>] [--json-all-extended-attributes] [--json-pretty] [--yaml-all-extended-attributes] [-v version] [--all-idl-features]
+                   [--gqlfield GQLFIELD GQLFIELD] [--jsonschema-all-extended-attributes] [--jsonschema-disallow-additional-properties] [--jsonschema-require-all-properties] [--jsonschema-pretty]
+                   [--validate-static-uid VALIDATE_STATIC_UID] [--only-validate-no-export] [--strict-mode]   
                    <vspec_file> <output_file>
 
 Convert vspec to other formats.
@@ -27,6 +28,7 @@ IDGEN arguments:
                         Path to validation file.
   --only-validate-no-export
                         For pytests and pipelines you can skip the export of the <output_file>
+  --strict-mode         Strict mode means that the generation of static UIDs is case-sensitive.
 ```
 
 ## Example
@@ -42,6 +44,9 @@ cd path/to/your/vss-tools
 
 Great, you generated your first overlay that will also be used as your validation file as soon as you update your
 vehicle signal specification file.
+
+If needed you can make the static UID generation case-sensitive using the command line argument `--strict-mode`. It
+will default to false.
 
 ### Generate e.g. yaml file with static UIDs
 

--- a/tests/vspec/test_static_uids/test_static_uids.py
+++ b/tests/vspec/test_static_uids/test_static_uids.py
@@ -11,18 +11,18 @@
 #
 
 import os
-import pytest
 import shlex
-import vspec
-import vspec.vssexporters.vss2id as vss2id
-import vspec2x
+from typing import Dict
+
+import pytest
 import yaml
 
-from typing import Dict
-from vspec.model.constants import VSSTreeType, VSSDataType, VSSUnit
+import vspec
+import vspec2x
+import vspec.vssexporters.vss2id as vss2id
+from vspec.model.constants import VSSDataType, VSSTreeType, VSSUnit
 from vspec.model.vsstree import VSSNode
 from vspec.utils.idgen_utils import get_all_keys_values
-
 
 # HELPERS
 
@@ -81,13 +81,13 @@ def change_test_dir(request, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "node_name, unit, datatype, allowed, minimum, maximum, result_static_uid",
+    "node_name, unit, datatype, allowed, minimum, maximum, result_static_uid, strict_mode",
     [
-        ("TestNode", "m", VSSDataType.UINT16, "", 0, 10000, "A1D565B2"),
-        ("TestNode", "mm", VSSDataType.UINT32, "", "", "", "B5D7A8FA"),
-        ("TestUnit", "degrees/s", VSSDataType.FLOAT, "", "", "", "DEA9138C"),
-        ("TestMinMax", "percent", VSSDataType.UINT8, "", 0, 100, "88FC5491"),
-        ("TestEnum", "m", VSSDataType.STRING, ["YES, NO"], "", "", "06AEB370"),
+        ("TestNode", "m", VSSDataType.UINT16, "", 0, 10000, "A1D565B2", False),
+        ("TestNode", "mm", VSSDataType.UINT32, "", "", "", "B5D7A8FA", False),
+        ("TestUnit", "degrees/s", VSSDataType.FLOAT, "", "", "", "DEA9138C", False),
+        ("TestMinMax", "percent", VSSDataType.UINT8, "", 0, 100, "88FC5491", False),
+        ("TestEnum", "m", VSSDataType.STRING, ["YES, NO"], "", "", "06AEB370", False),
     ],
 )
 def test_generate_id(
@@ -98,11 +98,52 @@ def test_generate_id(
     minimum: str,
     maximum: str,
     result_static_uid: str,
+    strict_mode: bool,
 ):
     node = get_test_node(node_name, unit, datatype, allowed, minimum, maximum)
-    result, _ = vss2id.generate_split_id(node, id_counter=0)
+    result, _ = vss2id.generate_split_id(node, id_counter=0, strict_mode=strict_mode)
 
     assert result == result_static_uid
+
+
+@pytest.mark.parametrize(
+    "node_name_case_sensitive, node_name_case_insensitive, strict_mode",
+    [
+        ("TestNode", "testnode", False),
+        ("TestNode", "testnode", True),
+    ],
+)
+def test_strict_mode(
+    node_name_case_sensitive: str, node_name_case_insensitive: str, strict_mode: bool
+):
+    node_case_sensitive = get_test_node(
+        node_name=node_name_case_sensitive,
+        unit="m",
+        datatype=VSSDataType.FLOAT,
+        allowed="",
+        minimum="",
+        maximum="",
+    )
+    result_case_sensitive, _ = vss2id.generate_split_id(
+        node_case_sensitive, id_counter=0, strict_mode=strict_mode
+    )
+
+    node_case_insensitive = get_test_node(
+        node_name=node_name_case_insensitive,
+        unit="m",
+        datatype=VSSDataType.FLOAT,
+        allowed="",
+        minimum="",
+        maximum="",
+    )
+    result_case_insensitive, _ = vss2id.generate_split_id(
+        node_case_insensitive, id_counter=0, strict_mode=strict_mode
+    )
+
+    if strict_mode:
+        assert result_case_sensitive != result_case_insensitive
+    else:
+        assert result_case_sensitive == result_case_insensitive
 
 
 @pytest.mark.parametrize(
@@ -122,10 +163,10 @@ def test_export_node(
         vspec_file, include_paths=["."], tree_type=VSSTreeType.SIGNAL_TREE
     )
     yaml_dict: Dict[str, str] = {}
-    vss2id.export_node(yaml_dict, tree, id_counter=0)
+    vss2id.export_node(yaml_dict, tree, id_counter=0, strict_mode=False)
 
     result_dict: Dict[str, str]
-    with open(os.path.join(dir_path, validation_file), "r") as f:
+    with open(os.path.join(dir_path, validation_file)) as f:
         result_dict = yaml.load(f, Loader=yaml.FullLoader)
 
     assert result_dict.keys() == yaml_dict.keys()
@@ -149,11 +190,7 @@ def test_duplicate_hash(caplog: pytest.LogCaptureFixture, children_names: list):
     if children_names[0] == children_names[1]:
         # assert system exit and log
         with pytest.raises(SystemExit) as pytest_wrapped_e:
-            vss2id.export_node(
-                yaml_dict,
-                tree,
-                id_counter=0,
-            )
+            vss2id.export_node(yaml_dict, tree, id_counter=0, strict_mode=False)
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == -1
         assert len(caplog.records) == 1 and all(
@@ -161,11 +198,7 @@ def test_duplicate_hash(caplog: pytest.LogCaptureFixture, children_names: list):
         )
     else:
         # assert all IDs different
-        vss2id.export_node(
-            yaml_dict,
-            tree,
-            id_counter=0,
-        )
+        vss2id.export_node(yaml_dict, tree, id_counter=0, strict_mode=False)
         assigned_ids: list = []
         for key, value in get_all_keys_values(yaml_dict):
             if not isinstance(value, dict) and key == "staticUID":

--- a/vspec/utils/idgen_utils.py
+++ b/vspec/utils/idgen_utils.py
@@ -6,6 +6,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+
 def get_node_identifier_bytes(
     qualified_name: str,
     data_type: str,
@@ -14,6 +15,7 @@ def get_node_identifier_bytes(
     allowed: str,
     minimum: str,
     maximum: str,
+    strict_mode: bool,
 ) -> bytes:
     """Get a node identifier as bytes. Used as an input for hashing
 
@@ -24,10 +26,11 @@ def get_node_identifier_bytes(
     @param allowed: the enum for allowed values
     @param minimum: min value for the data if exists
     @param maximum: max value for the data if exists
+    @param strict_mode: strict mode means case sensitivity of node qualified names
     @return: a bytes representation of the node
     """
 
-    return (
+    node_identifier: bytes = (
         f"{qualified_name}: "
         f"unit: {unit}, "
         f"datatype: {data_type}, "
@@ -35,7 +38,12 @@ def get_node_identifier_bytes(
         f"allowed: {allowed}"
         f"min: {minimum}"
         f"max: {maximum}"
-    ).encode("utf-8").lower()
+    ).encode()
+
+    if strict_mode:
+        return node_identifier
+    else:
+        return node_identifier.lower()
 
 
 def fnv1_32_hash(identifier: bytes) -> int:
@@ -52,12 +60,13 @@ def fnv1_32_hash(identifier: bytes) -> int:
     return id_hash
 
 
-def fnv1_32_wrapper(name: str, source: dict):
+def fnv1_32_wrapper(name: str, source: dict, strict_mode: bool):
     """A wrapper for the 32-bit hashing function if the input node
      is represented as dict instead of VSSNode
 
     @param name: full name aka qualified name
     @param source:
+    @param strict_mode: strict mode means case sensitivity of node qualified names
     @return:
     """
     allowed: str = source["allowed"] if "allowed" in source.keys() else ""
@@ -71,6 +80,7 @@ def fnv1_32_wrapper(name: str, source: dict):
         allowed,
         minimum,
         maximum,
+        strict_mode,
     )
     return format(fnv1_32_hash(identifier), "08X")
 

--- a/vspec/utils/vss2id_val.py
+++ b/vspec/utils/vss2id_val.py
@@ -6,11 +6,13 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-from anytree import PreOrderIter  # type: ignore
 import argparse
 import logging
 import sys
 from typing import Optional
+
+from anytree import PreOrderIter  # type: ignore
+
 from vspec.model.vsstree import VSSNode
 from vspec.utils.idgen_utils import fnv1_32_wrapper
 
@@ -40,19 +42,20 @@ def validate_static_uids(
                 f"vspec: '{v['description']}'"
             )
 
-    def check_semantics(k: str, v: dict) -> Optional[int]:
+    def check_semantics(k: str, v: dict, strict_mode: bool) -> Optional[int]:
         """Checks if the change was a semantic or path change. This can be triggered by
         manually adding a fka (formerly known as) attribute to the vspec. The result
         is that the old hash can be matched such that a node keeps the same UID.
 
         @param k: the current key
         @param v: the current value (dict)
+        @param strict_mode: strict mode means case sensitivity for static UID generation
         @return: boolean if it was a semantic or path change
         """
         if "fka" in v.keys():
             semantic_match: Optional[int] = None
             for fka_val in v["fka"]:
-                old_static_uid = "0x" + fnv1_32_wrapper(fka_val, v)
+                old_static_uid = "0x" + fnv1_32_wrapper(fka_val, v, strict_mode)
                 for i, validation_node in enumerate(validation_tree_nodes):
                     if (
                         old_static_uid
@@ -106,7 +109,7 @@ def validate_static_uids(
 
             # if not matched via UID check semantics or path change
             if len(matched_uids) == 0:
-                semantic_match = check_semantics(key, value)
+                semantic_match = check_semantics(key, value, config.strict_mode)
                 if semantic_match is None:
                     key_found: bool = False
                     for i, node in enumerate(validation_tree_nodes):

--- a/vspec/vssexporters/vss2id.py
+++ b/vspec/vssexporters/vss2id.py
@@ -15,17 +15,16 @@ import logging
 import os
 import sys
 from typing import Dict, Tuple
+
+import yaml
+
 from vspec import load_tree
-from vspec.model.constants import VSSTreeType
 from vspec.loggingconfig import initLogging
+from vspec.model.constants import VSSTreeType
 from vspec.model.vsstree import VSSNode
 from vspec.utils import vss2id_val
-from vspec.utils.idgen_utils import (
-    get_node_identifier_bytes,
-    fnv1_32_hash,
-    get_all_keys_values,
-)
-import yaml
+from vspec.utils.idgen_utils import (fnv1_32_hash, get_all_keys_values,
+                                     get_node_identifier_bytes)
 
 
 def add_arguments(parser: argparse.ArgumentParser) -> None:
@@ -42,13 +41,21 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         default=False,
         help="For pytests and pipelines you can skip the export of the vspec file.",
     )
+    parser.add_argument(
+        "--strict-mode",
+        action="store_true",
+        help="Strict mode means that the generation of static UIDs is case sensitive.",
+    )
 
 
-def generate_split_id(node: VSSNode, id_counter: int) -> Tuple[str, int]:
+def generate_split_id(
+    node: VSSNode, id_counter: int, strict_mode: bool
+) -> Tuple[str, int]:
     """Generates static UIDs using 4-byte FNV-1 hash.
 
     @param node: VSSNode that we want to generate a static UID for
     @param id_counter: consecutive numbers counter for amount of nodes
+    @param strict_mode: strict mode means case sensitivity for static UID generation
     @return: tuple of hashed string and id counter
     """
 
@@ -60,21 +67,23 @@ def generate_split_id(node: VSSNode, id_counter: int) -> Tuple[str, int]:
         node.allowed,
         node.min,
         node.max,
+        strict_mode,
     )
     hashed_str = format(fnv1_32_hash(identifier), "08X")
 
     return hashed_str, id_counter + 1
 
 
-def export_node(yaml_dict, node, id_counter) -> Tuple[int, int]:
+def export_node(yaml_dict, node, id_counter, strict_mode: bool) -> Tuple[int, int]:
     """Recursive function to export the full tree to a dict
 
     @param yaml_dict: the to be exported dict
     @param node: parent node of the tree
     @param id_counter: counter for amount of ids
+    @param strict_mode: strict mode means case sensitivity for static UID generation
     @return: id_counter, id_counter
     """
-    node_id, id_counter = generate_split_id(node, id_counter)
+    node_id, id_counter = generate_split_id(node, id_counter, strict_mode)
 
     # check for hash duplicates
     for key, value in get_all_keys_values(yaml_dict):
@@ -114,11 +123,7 @@ def export_node(yaml_dict, node, id_counter) -> Tuple[int, int]:
         yaml_dict[node_path]["deprecation"] = node.deprecation
 
     for child in node.children:
-        id_counter, id_counter = export_node(
-            yaml_dict,
-            child,
-            id_counter,
-        )
+        id_counter, id_counter = export_node(yaml_dict, child, id_counter, strict_mode)
 
     return id_counter, id_counter
 
@@ -134,7 +139,9 @@ def export(config: argparse.Namespace, signal_root: VSSNode, print_uuid):
 
     id_counter: int = 0
     signals_yaml_dict: Dict[str, str] = {}  # Use str for ID values
-    id_counter, _ = export_node(signals_yaml_dict, signal_root, id_counter)
+    id_counter, _ = export_node(
+        signals_yaml_dict, signal_root, id_counter, config.strict_mode
+    )
 
     if config.validate_static_uid:
         logging.info(

--- a/vspec/vssexporters/vss2id.py
+++ b/vspec/vssexporters/vss2id.py
@@ -44,7 +44,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--strict-mode",
         action="store_true",
-        help="Strict mode means that the generation of static UIDs is case sensitive.",
+        help="Strict mode means that the generation of static UIDs is case-sensitive.",
     )
 
 


### PR DESCRIPTION
If you want to run the ID generation case sensitive then use `--strict-mode` if not you can just run it without it